### PR TITLE
完了処理をREST分離＆未チェック時の警告修正

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,5 @@
 class TasksController < ApplicationController
-  before_action :set_task, only: %i[ show edit update ]
+  before_action :set_task, only: %i[ show edit update complete ]
 
   # GET /tasks or /tasks.json
   def index
@@ -35,11 +35,8 @@ class TasksController < ApplicationController
 
   # PATCH/PUT /tasks/1 or /tasks/1.json
   def update
-    Rails.logger.debug params.inspect
-    return redirect_without_check unless checked?
-
-    if @task.update(completed: true)
-      redirect_to tasks_path, notice: "タスクを完了しました"
+    if @task.update(task_params)
+      redirect_to tasks_path, notice: notice_message
     else
       render :edit, status: :unprocessable_entity
     end
@@ -55,6 +52,15 @@ class TasksController < ApplicationController
   #   end
   # end
 
+  def complete
+    if params.dig(:task, :completed) != "1"
+      return redirect_to tasks_path, alert: "完了するにはチェックを入れてください。"
+    end
+
+    @task.update(completed: true)
+    redirect_to tasks_path, notice: notice_message
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_task
@@ -66,11 +72,15 @@ class TasksController < ApplicationController
       params.require(:task).permit(:title, :priority, :completed)
     end
 
-    def checked?
-      params.dig(:task, :completed) == "1"
-    end
-
-    def redirect_without_check
-      redirect_to tasks_path, alert: "完了するにはチェックを入れてください。"
+    def notice_message
+      if @task.saved_change_to_completed?
+        "タスクを完了しました"
+      elsif @task.saved_change_to_title?
+        "タスク名を変更しました"
+      elsif @task.saved_change_to_priority?
+        "優先度を変更しました"
+      else
+        "タスクを更新しました"
+      end
     end
 end

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -9,7 +9,10 @@
       </p>
     </div>
     <div>
-      <%= form_with model: task, local: true do |f|%>
+      <%= form_with model: task,
+                    url: complete_task_path(task),
+                    method: :patch,
+                    local: true do |f|%>
         <%= f.check_box :completed %>
         <%= f.submit "完了", class: "btn" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :tasks, except: [ :destroy ] do
+  resources :tasks do
     member do
       patch :complete
     end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -34,12 +34,11 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  def test_cannot_complete_without_check
-    patch task_url(@task), params: { task: { completed: "0" } }
+  test "cannot complete task without checking box" do
+    patch complete_task_url(@task), params: { task: { completed: "0" } }
 
     assert_redirected_to tasks_url
-    follow_redirect!
-    assert_match "完了するにはチェックを入れてください", response.body
+    assert_equal "完了するにはチェックを入れてください。", flash[:alert]
   end
 
   # test "should destroy task" do


### PR DESCRIPTION
## 概要
- update と complete アクションを分離
- チェック未入力時に「完了するにはチェックを入れてください。」表示
- notice_message を状況別に分岐
- controller test 修正

## 確認方法
- チェックなし→警告表示
- チェックあり→タスク完了
- rails test が全て通過