### PR TITLE
brakemanのバージョンアップ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
   gem "bundler-audit", require: false
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", "~> 8.0", require: false
+  gem "brakeman", "~> 8.0.4", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman (~> 8.0)
+  brakeman (~> 8.0.4)
   bundler-audit
   capybara
   debug


### PR DESCRIPTION
## 概要
gem brakemanを最新バージョンの8.0.4に引き上げました。

## 背景
セキュリティの脆弱性によるエラーのため。

## 確認方法
GemfileとGemfile.lockの差分をご確認ください。