### PR TITLE
タスク作成失敗時のレイアウト調整と日本語化

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -79,3 +79,7 @@ hr{
 
 .flash-notice { color: green; }
 .flash-alert  { color: red; }
+
+.field_with_errors {
+  display: inline;
+}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -25,11 +25,8 @@ class TasksController < ApplicationController
 
     if @task.save
       redirect_to tasks_path, notice: "タスクの作成が成功しました。"
-      # format.json { render :show, status: :created, location: @task }
     else
-      flash.now[:alert] = "タスクの作成に失敗しました。"
       render :new, status: :unprocessable_entity
-      # format.json { render json: @task.errors, status: :unprocessable_entity }
     end
   end
 

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: task) do |form| %>
   <% if task.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(task.errors.count, "error") %> prohibited this task from being saved:</h2>
+      <h2>入力内容にエラーがあります</h2>
 
       <ul>
         <% task.errors.each do |error| %>
@@ -18,9 +18,18 @@
 
   <div class="form-group">
     <%= form.label "優先度", style: "display: block" %>
-    <%= form.radio_button :priority, :high %><%= form.label :priority, "高" %>
-    <%= form.radio_button :priority, :medium %><%= form.label :priority, "中" %>
-    <%= form.radio_button :priority, :low %><%= form.label :priority, "底" %>
+
+    <label>
+      <%= form.radio_button :priority, "high" %> 高
+    </label>
+
+    <label>
+      <%= form.radio_button :priority, "medium" %> 中
+    </label>
+
+    <label>
+      <%= form.radio_button :priority, "low" %> 低
+    </label>
   </div>
 
   <!--

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,12 @@
 ja:
+  activerecord:
+    attributes:
+      task:
+        title: "タスク名"
+        priority: "優先度"
   enums: 
     task:
       priority:
         high: "★ 高"
         medium: "⚫︎ 中"
-        low: "・ 底"
+        low: "・ 低"


### PR DESCRIPTION
## 概要
- タスク作成画面において、タスク作成失敗時にレイアウトが崩れるのを修正。
- エラーメッセージの表示を日本語に修正。

## 原因と対応内容
タスク作成画面でバリデーションエラー発生時にレイアウトが崩れる問題を修正しました。  
Railsのfield_with_errorsによってradioボタンがdivでラップされることで  
レイアウトが崩れていたためCSSで調整しました。

またi18nで以下の2単語を日本語化しました。
- Title：タスク名
- Priority：優先度

## 確認方法
1. タスク作成画面を開く
1. タスク名と優先度を未入力で作成ボタンを押す
1. エラーメッセージが日本語で表示されること
1. 優先度のラジオボタンのレイアウトが崩れないこと